### PR TITLE
Split validation results into its own dock widget

### DIFF
--- a/redistrict/gui/redistricting_dock_widget.py
+++ b/redistrict/gui/redistricting_dock_widget.py
@@ -66,6 +66,7 @@ class RedistrictingDockWidget(QgsDockWidget):
         :param html: HTML to show
         """
         self.frame.setHtml(html)
+        self.setUserVisible(True)
 
     def anchor_clicked(self, link: QUrl):
         """

--- a/redistrict/linz/electorate_changes_queue.py
+++ b/redistrict/linz/electorate_changes_queue.py
@@ -13,7 +13,7 @@ __copyright__ = 'Copyright 2018, LINZ'
 # This will get replaced with a git SHA1 when you do a git archive
 __revision__ = '$Format:%H$'
 
-from qgis.core import (QgsMessageLog, QgsVectorLayer,
+from qgis.core import (QgsVectorLayer,
                        QgsFeatureRequest)
 from qgis.PyQt.QtWidgets import (QUndoCommand,
                                  QUndoStack)
@@ -46,13 +46,11 @@ class QueueItem(QUndoCommand):
         self.electorate_layer.dataProvider().changeGeometryValues(self.new_geometries)
         self.electorate_layer.dataProvider().changeAttributeValues(self.new_attributes)
         self.electorate_layer.triggerRepaint()
-        QgsMessageLog.logMessage('redoing')
 
     def undo(self):  # pylint: disable=missing-docstring
         self.electorate_layer.dataProvider().changeGeometryValues(self.previous_geometries)
         self.electorate_layer.dataProvider().changeAttributeValues(self.previous_attributes)
         self.electorate_layer.triggerRepaint()
-        QgsMessageLog.logMessage('undoing')
 
     def id(self):  # pylint: disable=missing-docstring
         return -1

--- a/redistrict/linz/linz_redistricting_dock_widget.py
+++ b/redistrict/linz/linz_redistricting_dock_widget.py
@@ -13,16 +13,8 @@ __copyright__ = 'Copyright 2018, LINZ'
 # This will get replaced with a git SHA1 when you do a git archive
 __revision__ = '$Format:%H$'
 
-from functools import partial
-from qgis.PyQt.QtCore import Qt
-from qgis.PyQt.QtWidgets import (QTableWidget,
-                                 QTableWidgetItem,
-                                 QToolButton)
-from qgis.core import QgsRectangle
-from redistrict.gui.gui_utils import GuiUtils
 from redistrict.gui.redistricting_dock_widget import RedistrictingDockWidget
 from redistrict.linz.linz_redistricting_context import LinzRedistrictingContext
-from redistrict.linz.validation_task import ValidationTask
 
 
 class LinzRedistrictingDockWidget(RedistrictingDockWidget):
@@ -39,7 +31,6 @@ class LinzRedistrictingDockWidget(RedistrictingDockWidget):
         super().__init__(iface)
         self.setObjectName('LinzRedistrictingDock')
         self.update_dock_title(context=context)
-        self.table = None
         self.request_population_callback = None
 
     def update_dock_title(self, context: LinzRedistrictingContext):
@@ -50,81 +41,6 @@ class LinzRedistrictingDockWidget(RedistrictingDockWidget):
         """
         self.setWindowTitle(self.tr('Redistricting - {} - {}').format(context.get_name_for_current_task(),
                                                                       context.get_name_for_current_scenario()))
-
-    def show_message(self, html):
-        """
-        Shows a HTML formatted message in the dock, replacing
-        its current contents
-        :param html: HTML to show
-        """
-        if self.table is not None:
-            self.table.deleteLater()
-            self.table = None
-
-        super().show_message(html)
-
-    def zoom_to_extent(self, extent: QgsRectangle):
-        """
-        Zooms the canvas to the given extent
-        :param extent: extent to zoom to
-        """
-        self.iface.mapCanvas().zoomToFeatureExtent(extent)
-
-    def show_validation_results(self, results):
-        """
-        Shows the results of a validation run
-        :param results: validation results
-        """
-        if self.table is not None:
-            self.table.deleteLater()
-
-        self.table = QTableWidget()
-        self.table.setColumnCount(3)
-        self.table.setHorizontalHeaderLabels(['', 'Electorate', 'Error'])
-
-        def create_zoom_button(extent: QgsRectangle):
-            """
-            Creates a zoom to electorate button
-            :param extent: extent to zoom to
-            """
-            button = QToolButton()
-            button.setToolTip('Zoom to Electorate')
-            button.setIcon(GuiUtils.get_icon('zoom_selected.svg'))
-            button.clicked.connect(partial(self.zoom_to_extent, extent))
-            return button
-
-        self.table.setRowCount(0)
-
-        def add_electorate(electorate_id, name: str, error: str,  # pylint: disable=unused-argument
-                           extent: QgsRectangle):
-            """
-            Adds an electorate to the results table
-            :param electorate_id: electorate ID
-            :param name: electorate name
-            :param error: error string
-            :param extent: extent of electorate geometry
-            """
-            flags = Qt.ItemIsSelectable | Qt.ItemIsEnabled
-            name_item = QTableWidgetItem(name)
-            name_item.setFlags(flags)
-            error_item = QTableWidgetItem(error)
-            error_item.setFlags(flags)
-
-            row = self.table.rowCount()
-            self.table.setRowCount(row + 1)
-
-            self.table.setItem(row, 1, name_item)
-            self.table.setItem(row, 2, error_item)
-            self.table.setCellWidget(row, 0, create_zoom_button(extent))
-
-        for result in results:
-            add_electorate(electorate_id=result[ValidationTask.ELECTORATE_ID],
-                           name=result[ValidationTask.ELECTORATE_NAME],
-                           error=result[ValidationTask.ERROR],
-                           extent=result[ValidationTask.ELECTORATE_GEOMETRY].boundingBox())
-
-        self.table.setColumnWidth(0, 30)
-        self.widget().layout().addWidget(self.table, 1, 0, 1, 1)
 
     def anchor_clicked(self, link):
         if self.request_population_callback is not None:

--- a/redistrict/linz/linz_validation_results_dock_widget.py
+++ b/redistrict/linz/linz_validation_results_dock_widget.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""LINZ Redistricting Plugin - Validation results dock widget
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+
+__author__ = '(C) 2018 by Nyall Dawson'
+__date__ = '20/04/2018'
+__copyright__ = 'Copyright 2018, LINZ'
+# This will get replaced with a git SHA1 when you do a git archive
+__revision__ = '$Format:%H$'
+
+from functools import partial
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtWidgets import (QGridLayout,
+                                 QWidget,
+                                 QTableWidget,
+                                 QTableWidgetItem,
+                                 QToolButton)
+from qgis.core import QgsRectangle
+from qgis.gui import QgsDockWidget
+from qgis.utils import iface
+from redistrict.gui.gui_utils import GuiUtils
+from redistrict.linz.validation_task import ValidationTask
+
+
+class LinzValidationResultsDockWidget(QgsDockWidget):
+    """
+    LINZ Specific validation results dock widget
+    """
+
+    def __init__(self, _iface=None):
+        """
+        Constructor for LINZ redistricting dock
+        :param context: initial dock context
+        :param iface: QGIS interface
+        """
+        super().__init__()
+
+        if _iface is not None:
+            self.iface = _iface
+        else:
+            self.iface = iface
+
+        dock_contents = QWidget()
+        grid = QGridLayout(dock_contents)
+        grid.setContentsMargins(0, 0, 0, 0)
+
+        self.setWidget(dock_contents)
+
+        self.setObjectName('LinzValidationResultsDock')
+        self.setWindowTitle(self.tr('Validation Results'))
+        self.table = None
+
+    def zoom_to_extent(self, extent: QgsRectangle):
+        """
+        Zooms the canvas to the given extent
+        :param extent: extent to zoom to
+        """
+        self.iface.mapCanvas().zoomToFeatureExtent(extent)
+
+    def show_validation_results(self, results):
+        """
+        Shows the results of a validation run
+        :param results: validation results
+        """
+        if self.table is not None:
+            self.table.deleteLater()
+
+        self.table = QTableWidget()
+        self.table.setColumnCount(3)
+        self.table.setHorizontalHeaderLabels(['', 'Electorate', 'Error'])
+
+        def create_zoom_button(extent: QgsRectangle):
+            """
+            Creates a zoom to electorate button
+            :param extent: extent to zoom to
+            """
+            button = QToolButton()
+            button.setToolTip('Zoom to Electorate')
+            button.setIcon(GuiUtils.get_icon('zoom_selected.svg'))
+            button.clicked.connect(partial(self.zoom_to_extent, extent))
+            return button
+
+        self.table.setRowCount(0)
+
+        def add_electorate(electorate_id, name: str, error: str,  # pylint: disable=unused-argument
+                           extent: QgsRectangle):
+            """
+            Adds an electorate to the results table
+            :param electorate_id: electorate ID
+            :param name: electorate name
+            :param error: error string
+            :param extent: extent of electorate geometry
+            """
+            flags = Qt.ItemIsSelectable | Qt.ItemIsEnabled
+            name_item = QTableWidgetItem(name)
+            name_item.setFlags(flags)
+            error_item = QTableWidgetItem(error)
+            error_item.setFlags(flags)
+
+            row = self.table.rowCount()
+            self.table.setRowCount(row + 1)
+
+            self.table.setItem(row, 1, name_item)
+            self.table.setItem(row, 2, error_item)
+            self.table.setCellWidget(row, 0, create_zoom_button(extent))
+
+        for result in results:
+            add_electorate(electorate_id=result[ValidationTask.ELECTORATE_ID],
+                           name=result[ValidationTask.ELECTORATE_NAME],
+                           error=result[ValidationTask.ERROR],
+                           extent=result[ValidationTask.ELECTORATE_GEOMETRY].boundingBox())
+
+        self.table.setColumnWidth(0, 30)
+        self.widget().layout().addWidget(self.table, 1, 0, 1, 1)

--- a/redistrict/test/test_linz_dock.py
+++ b/redistrict/test/test_linz_dock.py
@@ -15,11 +15,9 @@ __copyright__ = 'Copyright 2018, LINZ'
 __revision__ = '$Format:%H$'
 
 import unittest
-from qgis.core import QgsGeometry
 from redistrict.linz.linz_redistricting_dock_widget import LinzRedistrictingDockWidget
 from redistrict.linz.linz_redistricting_context import LinzRedistrictingContext
 from redistrict.linz.scenario_registry import ScenarioRegistry
-from redistrict.linz.validation_task import ValidationTask
 from redistrict.test.test_linz_scenario_registry import make_scenario_layer
 from .utilities import get_qgis_app
 
@@ -56,41 +54,6 @@ class LinzRedistrictingDockWidgetTest(unittest.TestCase):
         context.scenario = 3
         widget.update_dock_title(context=context)
         self.assertEqual(widget.windowTitle(), 'Redistricting - General (North Island) - scenario 3')
-
-    def testShowResults(self):
-        """
-        Test showing validation results
-        """
-        scenario_layer = make_scenario_layer()
-        scenario_registry = ScenarioRegistry(source_layer=scenario_layer, id_field='id', name_field='name',
-                                             meshblock_electorate_layer=None)
-        context = LinzRedistrictingContext(scenario_registry=scenario_registry)
-        widget = LinzRedistrictingDockWidget(context=context, iface=IFACE)
-        widget.show_validation_results([{ValidationTask.ELECTORATE_ID: 1, ValidationTask.ELECTORATE_NAME: 'name 1',
-                                         ValidationTask.ERROR: 'error 1',
-                                         ValidationTask.ELECTORATE_GEOMETRY: QgsGeometry()},
-                                        {ValidationTask.ELECTORATE_ID: 2, ValidationTask.ELECTORATE_NAME: 'name 2',
-                                         ValidationTask.ERROR: 'error 2',
-                                         ValidationTask.ELECTORATE_GEOMETRY: QgsGeometry()}])
-        self.assertEqual(widget.table.rowCount(), 2)
-        self.assertEqual(widget.table.item(0, 1).text(), 'name 1')
-        self.assertEqual(widget.table.item(0, 2).text(), 'error 1')
-        self.assertEqual(widget.table.item(1, 1).text(), 'name 2')
-        self.assertEqual(widget.table.item(1, 2).text(), 'error 2')
-        widget.show_validation_results([{ValidationTask.ELECTORATE_ID: 1, ValidationTask.ELECTORATE_NAME: 'name 1',
-                                         ValidationTask.ERROR: 'error 1',
-                                         ValidationTask.ELECTORATE_GEOMETRY: QgsGeometry()}])
-        self.assertEqual(widget.table.rowCount(), 1)
-        self.assertEqual(widget.table.item(0, 1).text(), 'name 1')
-        self.assertEqual(widget.table.item(0, 2).text(), 'error 1')
-
-        # pretend click
-        widget.table.cellWidget(0, 0).click()
-
-        # hide table
-        widget.show_message('Test<br />Message')
-        self.assertIn('Test<br />Message', widget.frame.toHtml())
-        self.assertIsNone(widget.table)
 
 
 if __name__ == "__main__":

--- a/redistrict/test/test_linz_validation_results_dock.py
+++ b/redistrict/test/test_linz_validation_results_dock.py
@@ -1,0 +1,66 @@
+# coding=utf-8
+"""LINZ Interactive Validation Results Dock test.
+
+.. note:: This program is free software; you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+     the Free Software Foundation; either version 2 of the License, or
+     (at your option) any later version.
+
+"""
+
+__author__ = '(C) 2018 by Nyall Dawson'
+__date__ = '1/05/2018'
+__copyright__ = 'Copyright 2018, LINZ'
+# This will get replaced with a git SHA1 when you do a git archive
+__revision__ = '$Format:%H$'
+
+import unittest
+from qgis.core import QgsGeometry
+from redistrict.linz.linz_validation_results_dock_widget import LinzValidationResultsDockWidget
+from redistrict.linz.validation_task import ValidationTask
+from .utilities import get_qgis_app
+
+QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
+
+
+class LinzValidationResultsDockWidgetTest(unittest.TestCase):
+    """Test LinzValidationResultsDockWidget."""
+
+    def testConstruct(self):
+        """
+        Test constructing dock
+        """
+        widget = LinzValidationResultsDockWidget(IFACE)
+        self.assertIsNotNone(widget)
+
+    def testShowResults(self):
+        """
+        Test showing validation results
+        """
+        widget = LinzValidationResultsDockWidget(IFACE)
+        widget.show_validation_results([{ValidationTask.ELECTORATE_ID: 1, ValidationTask.ELECTORATE_NAME: 'name 1',
+                                         ValidationTask.ERROR: 'error 1',
+                                         ValidationTask.ELECTORATE_GEOMETRY: QgsGeometry()},
+                                        {ValidationTask.ELECTORATE_ID: 2, ValidationTask.ELECTORATE_NAME: 'name 2',
+                                         ValidationTask.ERROR: 'error 2',
+                                         ValidationTask.ELECTORATE_GEOMETRY: QgsGeometry()}])
+        self.assertEqual(widget.table.rowCount(), 2)
+        self.assertEqual(widget.table.item(0, 1).text(), 'name 1')
+        self.assertEqual(widget.table.item(0, 2).text(), 'error 1')
+        self.assertEqual(widget.table.item(1, 1).text(), 'name 2')
+        self.assertEqual(widget.table.item(1, 2).text(), 'error 2')
+        widget.show_validation_results([{ValidationTask.ELECTORATE_ID: 1, ValidationTask.ELECTORATE_NAME: 'name 1',
+                                         ValidationTask.ERROR: 'error 1',
+                                         ValidationTask.ELECTORATE_GEOMETRY: QgsGeometry()}])
+        self.assertEqual(widget.table.rowCount(), 1)
+        self.assertEqual(widget.table.item(0, 1).text(), 'name 1')
+        self.assertEqual(widget.table.item(0, 2).text(), 'error 1')
+
+        # pretend click
+        widget.table.cellWidget(0, 0).click()
+
+
+if __name__ == "__main__":
+    suite = unittest.makeSuite(LinzValidationResultsDockWidgetTest)
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite)


### PR DESCRIPTION
Allowing it to be displayed at the same time as the redistrict
stats window

Fixes #70