### PR TITLE
 Disable actions during validation and mesh block exports

### DIFF
--- a/redistrict/linz/export_task.py
+++ b/redistrict/linz/export_task.py
@@ -19,7 +19,8 @@ from qgis.core import (QgsVectorLayer,
                        NULL)
 from redistrict.linz.linz_district_registry import LinzElectoralDistrictRegistry
 from redistrict.linz.scenario_registry import ScenarioRegistry
-from redistrict.linz.scenario_base_task import ScenarioBaseTask
+from redistrict.linz.scenario_base_task import (ScenarioBaseTask,
+                                                CanceledException)
 
 
 class ExportTask(ScenarioBaseTask):
@@ -56,7 +57,10 @@ class ExportTask(ScenarioBaseTask):
         self.user_log_layer = user_log_layer
 
     def run(self):  # pylint: disable=missing-docstring,too-many-locals
-        electorate_geometries, electorate_attributes = self.calculate_new_electorates()
+        try:
+            electorate_geometries, electorate_attributes = self.calculate_new_electorates()
+        except CanceledException:
+            return False
 
         # we also need a dictionary of meshblock number to all electorate types
         meshblock_electorates = {}

--- a/redistrict/linz/scenario_base_task.py
+++ b/redistrict/linz/scenario_base_task.py
@@ -25,7 +25,6 @@ class CanceledException(Exception):
     """
     Triggered when task is canceled
     """
-    pass
 
 
 class ScenarioBaseTask(QgsTask):

--- a/redistrict/linz/scenario_base_task.py
+++ b/redistrict/linz/scenario_base_task.py
@@ -21,6 +21,13 @@ from qgis.core import (QgsTask,
 from redistrict.linz.scenario_registry import ScenarioRegistry
 
 
+class CanceledException(Exception):
+    """
+    Triggered when task is canceled
+    """
+    pass
+
+
 class ScenarioBaseTask(QgsTask):
     """
     Base class for scenario related tasks
@@ -36,7 +43,8 @@ class ScenarioBaseTask(QgsTask):
     NON_OFFSHORE_MESHBLOCKS = 'NON_OFFSHORE_MESHBLOCKS'
     ESTIMATED_POP = 'ESTIMATED_POP'
 
-    def __init__(self, task_name: str, electorate_layer: QgsVectorLayer, meshblock_layer: QgsVectorLayer,  # pylint: disable=too-many-locals, too-many-statements
+    def __init__(self,  # pylint: disable=too-many-locals, too-many-statements
+                 task_name: str, electorate_layer: QgsVectorLayer, meshblock_layer: QgsVectorLayer,
                  meshblock_number_field_name: str, scenario_registry: ScenarioRegistry, scenario,
                  task: Optional[str] = None):
         """
@@ -132,6 +140,9 @@ class ScenarioBaseTask(QgsTask):
         electorate_attributes = {}
         i = 0
         for electorate_id, params in self.electorates_to_process.items():
+            if self.isCanceled():
+                raise CanceledException
+
             self.setProgress(100 * i / len(self.electorates_to_process))
 
             electorate_feature_id = params[self.ELECTORATE_FEATURE_ID]

--- a/redistrict/linz/scenario_switch_task.py
+++ b/redistrict/linz/scenario_switch_task.py
@@ -16,7 +16,8 @@ __revision__ = '$Format:%H$'
 from qgis.core import (QgsVectorLayer,
                        NULL)
 from redistrict.linz.scenario_registry import ScenarioRegistry
-from redistrict.linz.scenario_base_task import ScenarioBaseTask
+from redistrict.linz.scenario_base_task import (ScenarioBaseTask,
+                                                CanceledException)
 
 
 class ScenarioSwitchTask(ScenarioBaseTask):
@@ -55,7 +56,10 @@ class ScenarioSwitchTask(ScenarioBaseTask):
         assert self.stats_nz_var_23_field_index >= 0
 
     def run(self):  # pylint: disable=missing-docstring
-        electorate_geometries, electorate_attributes = self.calculate_new_electorates()
+        try:
+            electorate_geometries, electorate_attributes = self.calculate_new_electorates()
+        except CanceledException:
+            return False
 
         attribute_change_map = {}
         geometry_change_map = {}


### PR DESCRIPTION
Avoids issues relating to changing tables while an export/validation is in progress.