### PR TITLE
Use undo/redo queue for user log, so that user log entries

### DIFF
--- a/redistrict/linz/linz_redistrict_handler.py
+++ b/redistrict/linz/linz_redistrict_handler.py
@@ -234,9 +234,7 @@ class LinzRedistrictHandler(RedistrictHandler):
                                                                   self.stats_nz_var_23_field_index: NULL,
                                                                   self.invalid_field_index: NULL,
                                                                   self.invalid_reason_field_index: NULL}
-        self.electorate_changes_queue.push_changes(new_attributes, new_geometries)
-
-        self.user_log_layer.dataProvider().addFeatures(self.pending_log_entries)
+        self.electorate_changes_queue.push_changes(new_attributes, new_geometries, self.pending_log_entries)
 
         self.electorate_changes_queue.blocked = True
         super().end_edit_group()

--- a/redistrict/redistrict.py
+++ b/redistrict/redistrict.py
@@ -497,7 +497,8 @@ class LinzRedistrict(QObject):  # pylint: disable=too-many-public-methods
         self.switch_task.taskCompleted.connect(self.progress_item.close)
         self.switch_task.taskCompleted.connect(partial(self.start_editing_action.setEnabled, True))
         self.switch_task.taskTerminated.connect(self.progress_item.close)
-        self.electorate_edit_queue = ElectorateEditQueue(electorate_layer=self.electorate_layer)
+        self.electorate_edit_queue = ElectorateEditQueue(electorate_layer=self.electorate_layer,
+                                                         user_log_layer=self.user_log_layer)
 
         self.meshblock_layer.undoStack().indexChanged.connect(self.electorate_edit_queue.sync_to_meshblock_undostack_index)
         self.meshblock_layer.undoStack().indexChanged.connect(

--- a/redistrict/test/test_linz_redistrict_handler.py
+++ b/redistrict/test/test_linz_redistrict_handler.py
@@ -87,7 +87,7 @@ class LINZRedistrictHandlerTest(unittest.TestCase):
         self.assertTrue(success)
 
         user_log_layer = make_user_log_layer()
-        queue = ElectorateEditQueue(electorate_layer=district_layer)
+        queue = ElectorateEditQueue(electorate_layer=district_layer, user_log_layer=user_log_layer)
 
         handler = LinzRedistrictHandler(meshblock_layer=meshblock_layer, meshblock_number_field_name='fld1',
                                         target_field='fld1', electorate_changes_queue=queue,
@@ -231,7 +231,7 @@ class LINZRedistrictHandlerTest(unittest.TestCase):
         self.assertTrue(success)
 
         user_log_layer = make_user_log_layer()
-        queue = ElectorateEditQueue(electorate_layer=district_layer)
+        queue = ElectorateEditQueue(electorate_layer=district_layer, user_log_layer=user_log_layer)
 
         handler = LinzRedistrictHandler(meshblock_layer=meshblock_layer, meshblock_number_field_name='fld1',
                                         target_field='fld1', electorate_changes_queue=queue,


### PR DESCRIPTION
are atomically rolled back and forward with redistricting undo/redo operations

Fixes #77