### PR TITLE
Add floating dock window for showing the population of selected meshblocks

### DIFF
--- a/redistrict/images/population.svg
+++ b/redistrict/images/population.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16"><text x="-.239" y="10.792" font-weight="700" font-size="9.11" letter-spacing="0" word-spacing="0" font-family="DejaVu Sans Mono" fill="#555" stroke="#555" stroke-width=".417"><tspan x="-.239" y="10.792">123</tspan></text></svg>

--- a/redistrict/linz/load_meshblocks_task.py
+++ b/redistrict/linz/load_meshblocks_task.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+"""LINZ Redistricting Plugin - Load meshblocks task
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+
+__author__ = '(C) 2018 by Nyall Dawson'
+__date__ = '20/04/2018'
+__copyright__ = 'Copyright 2018, LINZ'
+# This will get replaced with a git SHA1 when you do a git archive
+__revision__ = '$Format:%H$'
+
+from typing import Optional
+from qgis.core import (QgsTask,
+                       QgsFeatureRequest,
+                       QgsVectorLayer,
+                       QgsGeometry)
+from redistrict.linz.scenario_registry import ScenarioRegistry
+
+
+class CanceledException(Exception):
+    """
+    Triggered when task is canceled
+    """
+
+
+class LoadMeshblocksTask(QgsTask):
+    """
+    Base class for scenario related tasks
+    """
+
+    ELECTORATE_FEATURE_ID = 'ELECTORATE_FEATURE_ID'
+    ELECTORATE_ID = 'ELECTORATE_ID'
+    ELECTORATE_TYPE = 'ELECTORATE_TYPE'
+    ELECTORATE_CODE = 'ELECTORATE_CODE'
+    ELECTORATE_NAME = 'ELECTORATE_NAME'
+    MESHBLOCKS = 'MESHBLOCKS'
+    OFFSHORE_MESHBLOCKS = 'OFFSHORE_MESHBLOCKS'
+    NON_OFFSHORE_MESHBLOCKS = 'NON_OFFSHORE_MESHBLOCKS'
+    ESTIMATED_POP = 'ESTIMATED_POP'
+
+    def __init__(self,  # pylint: disable=too-many-locals, too-many-statements
+                 task_name: str, electorate_layer: QgsVectorLayer, meshblock_layer: QgsVectorLayer,
+                 meshblock_number_field_name: str, scenario_registry: ScenarioRegistry, scenario,
+                 task: Optional[str] = None):
+        """
+        Constructor for ScenarioSwitchTask
+        :param task_name: user-visible, translated name for task
+        :param electorate_layer: electorate layer
+        :param meshblock_layer: meshblock layer
+        :param meshblock_number_field_name: name of meshblock number field
+        :param scenario_registry: scenario registry
+        :param scenario: target scenario id to switch to
+        :param task: current redistricting task
+        """
+        super().__init__(task_name)
+
+        self.scenario = scenario
+        self.electorate_layer = electorate_layer
+        self.task = task
+
+        self.type_idx = electorate_layer.fields().lookupField('type')
+        assert self.type_idx >= 0
+        self.scenario_id_idx = electorate_layer.fields().lookupField('scenario_id')
+        assert self.scenario_id_idx >= 0
+        self.estimated_pop_idx = electorate_layer.fields().lookupField('estimated_pop')
+        assert self.estimated_pop_idx >= 0
+        self.mb_number_idx = scenario_registry.meshblock_electorate_layer.fields().lookupField('meshblock_number')
+        assert self.mb_number_idx >= 0
+        self.mb_off_pop_m_idx = meshblock_layer.fields().lookupField('offline_pop_m')
+        assert self.mb_off_pop_m_idx >= 0
+        self.mb_off_pop_ni_idx = meshblock_layer.fields().lookupField('offline_pop_gn')
+        assert self.mb_off_pop_ni_idx >= 0
+        self.mb_off_pop_si_idx = meshblock_layer.fields().lookupField('offline_pop_gs')
+        assert self.mb_off_pop_si_idx >= 0
+        self.mb_offshore_idx = meshblock_layer.fields().lookupField('offshore')
+        assert self.mb_offshore_idx >= 0
+
+        self.invalid_reason_idx = self.electorate_layer.fields().lookupField('invalid_reason')
+        assert self.invalid_reason_idx >= 0
+        self.invalid_idx = self.electorate_layer.fields().lookupField('invalid')
+        assert self.invalid_idx >= 0
+
+        electorate_id_idx = electorate_layer.fields().lookupField('electorate_id')
+        assert electorate_id_idx >= 0
+        self.code_idx = electorate_layer.fields().lookupField('code')
+        assert self.code_idx >= 0
+        self.name_idx = electorate_layer.fields().lookupField('name')
+        assert self.name_idx >= 0
+        self.meshblock_number_idx = meshblock_layer.fields().lookupField(meshblock_number_field_name)
+        assert self.meshblock_number_idx >= 0
+
+        # do a bit of preparatory processing on the main thread for safety
+
+        # dict of meshblock number to feature
+        meshblocks = {}
+        for m in meshblock_layer.getFeatures():
+            meshblocks[int(m[self.meshblock_number_idx])] = m
+
+        # dict of electorates to process (by id)
+        self.electorates_to_process = {}
+        request = QgsFeatureRequest().setFlags(QgsFeatureRequest.NoGeometry)
+        request.setSubsetOfAttributes([electorate_id_idx, self.type_idx, self.code_idx, self.name_idx])
+        for electorate in electorate_layer.getFeatures(request):
+            # get meshblocks for this electorate in the target scenario
+            electorate_id = electorate[electorate_id_idx]
+            electorate_type = electorate[self.type_idx]
+            electorate_code = electorate[self.code_idx]
+            electorate_name = electorate[self.name_idx]
+            if self.task and electorate_type != self.task:
+                continue
+
+            electorate_meshblocks = scenario_registry.electorate_meshblocks(electorate_id=electorate_id,
+                                                                            electorate_type=electorate_type,
+                                                                            scenario_id=scenario)
+            assigned_meshblock_numbers = [m[self.mb_number_idx] for m in electorate_meshblocks]
+            matching_meshblocks = [meshblocks[m] for m in assigned_meshblock_numbers]
+            offshore_meshblocks = [m for m in matching_meshblocks if m[self.mb_offshore_idx]]
+            non_offshore_meshblocks = [m for m in matching_meshblocks if not m[self.mb_offshore_idx]]
+
+            self.electorates_to_process[electorate_id] = {self.ELECTORATE_FEATURE_ID: electorate.id(),
+                                                          self.ELECTORATE_TYPE: electorate_type,
+                                                          self.ELECTORATE_CODE: electorate_code,
+                                                          self.ELECTORATE_NAME: electorate_name,
+                                                          self.MESHBLOCKS: matching_meshblocks,
+                                                          self.OFFSHORE_MESHBLOCKS: offshore_meshblocks,
+                                                          self.NON_OFFSHORE_MESHBLOCKS: non_offshore_meshblocks}
+
+        self.setDependentLayers([electorate_layer])
+
+    def calculate_new_electorates(self):
+        """
+        Calculates the new electorate geometry and populations for the associated scenario
+        """
+        electorate_geometries = {}
+        electorate_attributes = {}
+        i = 0
+        for electorate_id, params in self.electorates_to_process.items():
+            if self.isCanceled():
+                raise CanceledException
+
+            self.setProgress(100 * i / len(self.electorates_to_process))
+
+            electorate_feature_id = params[self.ELECTORATE_FEATURE_ID]
+            electorate_type = params[self.ELECTORATE_TYPE]
+            matching_meshblocks = params[self.MESHBLOCKS]
+            offshore_meshblocks = params[self.OFFSHORE_MESHBLOCKS]
+            non_offshore_meshblocks = params[self.NON_OFFSHORE_MESHBLOCKS]
+
+            if electorate_type == 'M':
+                estimated_pop = sum(
+                    [mbf[self.mb_off_pop_m_idx] for mbf in matching_meshblocks if mbf[self.mb_off_pop_m_idx]])
+            elif electorate_type == 'GN':
+                estimated_pop = sum(
+                    [mbf[self.mb_off_pop_ni_idx] for mbf in matching_meshblocks if mbf[self.mb_off_pop_ni_idx]])
+            else:
+                estimated_pop = sum(
+                    [mbf[self.mb_off_pop_si_idx] for mbf in matching_meshblocks if mbf[self.mb_off_pop_si_idx]])
+
+            electorate_attributes[electorate_feature_id] = {self.ESTIMATED_POP: estimated_pop,
+                                                            self.ELECTORATE_ID: electorate_id,
+                                                            self.ELECTORATE_TYPE: electorate_type,
+                                                            self.ELECTORATE_NAME: params[self.ELECTORATE_NAME],
+                                                            self.ELECTORATE_CODE: params[self.ELECTORATE_CODE],
+                                                            self.MESHBLOCKS: matching_meshblocks,
+                                                            self.OFFSHORE_MESHBLOCKS: offshore_meshblocks,
+                                                            self.NON_OFFSHORE_MESHBLOCKS: non_offshore_meshblocks}
+
+            meshblock_parts = [m.geometry() for m in matching_meshblocks]
+            electorate_geometry = QgsGeometry.unaryUnion(meshblock_parts)
+            electorate_geometry = electorate_geometry.makeValid()
+            electorate_geometries[electorate_feature_id] = electorate_geometry
+            i += 1
+
+        return electorate_geometries, electorate_attributes

--- a/redistrict/linz/population_dock_widget.py
+++ b/redistrict/linz/population_dock_widget.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""LINZ Redistricting Plugin - Selected population dock widget
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+
+__author__ = '(C) 2018 by Nyall Dawson'
+__date__ = '20/04/2018'
+__copyright__ = 'Copyright 2018, LINZ'
+# This will get replaced with a git SHA1 when you do a git archive
+__revision__ = '$Format:%H$'
+
+from collections import defaultdict
+from qgis.PyQt.QtWidgets import (QWidget,
+                                 QGridLayout,
+                                 QTextBrowser)
+from qgis.core import (
+    QgsVectorLayer,
+    QgsFeatureRequest
+)
+from qgis.gui import (QgsDockWidget,
+                      QgisInterface)
+from qgis.utils import iface
+
+
+class SelectedPopulationDockWidget(QgsDockWidget):
+    """
+    Dock widget for display of population of selected meshblocks
+    """
+
+    def __init__(self, _iface: QgisInterface = None, meshblock_layer: QgsVectorLayer = None):
+        super().__init__()
+        self.setWindowTitle(self.tr('Selected Meshblock Population'))
+        self.meshblock_layer = meshblock_layer
+
+        if _iface is not None:
+            self.iface = _iface
+        else:
+            self.iface = iface
+
+        dock_contents = QWidget()
+        grid = QGridLayout(dock_contents)
+        grid.setContentsMargins(0, 0, 0, 0)
+
+        self.frame = QTextBrowser()
+        self.frame.setOpenLinks(False)
+        # self.frame.anchorClicked.connect(self.anchor_clicked)
+        grid.addWidget(self.frame, 1, 0, 1, 1)
+
+        self.setWidget(dock_contents)
+
+        self.meshblock_layer.selectionChanged.connect(self.selection_changed)
+        self.task = None
+        self.district_registry = None
+
+    def set_task(self, task: str):
+        """
+        Sets the current task to use when showing populations
+        """
+        self.task = task
+        self.selection_changed()
+
+    def set_district_registry(self, registry):
+        """
+        Sets the associated district registry
+        """
+        self.district_registry = registry
+        self.selection_changed()
+
+    def selection_changed(self):
+        """
+        Triggered when the selection in the meshblock layer changes
+        """
+        if not self.task or not self.district_registry:
+            return
+
+        request = QgsFeatureRequest().setFilterFids(self.meshblock_layer.selectedFeatureIds()).setFlags(QgsFeatureRequest.NoGeometry)
+
+        counts = defaultdict(int)
+        for f in self.meshblock_layer.getFeatures(request):
+            electorate = f['staged_electorate']
+            if self.task == 'GN':
+                pop = f['offline_pop_gn']
+            elif self.task == 'GS':
+                pop = f['offline_pop_gs']
+            else:
+                pop = f['offline_pop_m']
+            counts[electorate] += pop
+
+        html = '<p>'
+        for electorate, pop in counts.items():
+            html += """\n{}: <span style="font-weight:bold">{}</span><br>""".format(self.district_registry.get_district_title(electorate), pop)
+        html += '</p>'
+
+        self.frame.setHtml(html)


### PR DESCRIPTION
Toggled via a new action on the Redistricting Toolbar, this shows
a floating (or dockable) window with an updated count of the population
of selected meshblocks, tallied by assigned electorate.

Refs #79